### PR TITLE
Apache Cordova / Adobe PhoneGap

### DIFF
--- a/All_Repos.json
+++ b/All_Repos.json
@@ -174,6 +174,14 @@
      "branches": ["master"],
      "tags": [ "air", "bb10" ]
  },
+ "Cordova-Samples": {
+     "desc": "Samples showing how to write BlackBerry 10 Applications using Apache Cordova and Adobe PhoneGap",
+     "url": "http://github.com/blackberry/Cordova-Samples",
+     "type": "html5",
+     "branches": ["master"],
+     "note": "Adobe's PhoneGap is a distribution based on Apache Cordova.  We keep the samples for both here",
+     "tags": [ "html5", "bb10", "webworks", "cordova", "phonegap", "samples" ]
+ },
  "CouchDB": {
      "desc": "Port of CouchDB",
      "url": "http://github.com/blackberry/CouchDB",
@@ -497,6 +505,14 @@
      "type": "java",
      "branches": ["master"],
      "tags": [ "java", "bbos", "samples" ]
+ },
+ "Samples-for-PhoneGap": {
+     "desc": "Stand-in Repo. See Cordova-Samples",
+     "url": "http://github.com/blackberry/Samples-for-PhoneGap",
+     "type": "html5",
+     "branches": ["master"],
+     "note": "Adobe's PhoneGap is a distribution based on Apache Cordova.  We keep the samples for both in the Cordova-Samples repository",
+     "tags": [ "html5", "bb10", "webworks", "cordova", "phonegap", "samples" ]
  },
  "SBuilder": {
      "desc": "A tool for browsing and editing SQLite Databases",


### PR DESCRIPTION
Adobe PhoneGap is based on Apache Cordova and the two distributions are essentially the same.  We keep the samples in the Cordova-Samples repository but we also have added a Samples-for-PhoneGap repository so people interested in PhoneGap can find the right sources too.
