### PR TITLE
Fixed small typo in sample description

### DIFF
--- a/All_Samples.json
+++ b/All_Samples.json
@@ -307,7 +307,7 @@
      "tags": [ "html5", "webworks", "bb10", "camera" ]
  },
  "canvasToFilesystem": {
-     "desc": "Sample implementation of saving <canvas> contents to the BlackBerry 10 filesystem.",
+     "desc": "Sample implementation of saving &lt;canvas&gt; contents to the BlackBerry 10 filesystem.",
      "url": "https://github.com/blackberry/BB10-WebWorks-Samples/tree/master/canvasToFilesystem",
      "repo": "BB10-WebWorks-Samples",
      "repourl": "http://github.com/blackberry/BB10-WebWorks-Samples",


### PR DESCRIPTION
The reference to the "<canvas>" element in the description field of All_Samples.json needed to be escape or converted to entity references.
