### PR TITLE
Added quotes to correct JSON.

### DIFF
--- a/All_Samples.json
+++ b/All_Samples.json
@@ -1417,7 +1417,7 @@
      "url": "https://github.com/blackberry/Cascades-Samples/tree/master/mapanimations",
      "repo": "Cascades-Samples",
      "repourl": "http://github.com/blackberry/Cascades-Samples",
-     "tags": [ "native", "client", "bb10", "cascades", "map", animation ]
+     "tags": [ "native", "client", "bb10", "cascades", "map", "animation" ]
  },
  "mapview": {
      "desc": "Displays a city map overlayed with three sliders and also shows how to drop push pins on chosen locations",


### PR DESCRIPTION
Invalid JSON with quotes missing (unless you've defined a variable animation somewhere we don't have access to...)
